### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "marked": "^16.1.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/MainContent.jsx
+++ b/src/MainContent.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
 
 export default function MainContent() {
     const [articles, setArticles] = useState([]);
@@ -50,8 +51,8 @@ export default function MainContent() {
 
                         const content = await marked.parse(lines.slice(contentStartIndex).join("\n"));
 
-                        // Create preview by removing HTML tags and truncating
-                        const textContent = content.replace(/<[^>]*>/g, "");
+                        // Create preview by sanitizing HTML and truncating
+                        const textContent = sanitizeHtml(content, { allowedTags: [], allowedAttributes: {} });
                         const preview = textContent.length > 300
                             ? textContent.substring(0, 150) + '...'
                             : textContent;


### PR DESCRIPTION
Potential fix for [https://github.com/The-Scratch-Channel/the-scratch-channel.github.io/security/code-scanning/13](https://github.com/The-Scratch-Channel/the-scratch-channel.github.io/security/code-scanning/13)

To address the issue, we should replace the custom regular expression-based sanitization with a well-tested library like `sanitize-html`. This library is specifically designed to handle HTML sanitization and ensures that all unsafe tags and attributes are removed. By using `sanitize-html`, we can avoid the pitfalls of incomplete or incorrect regular expressions and ensure robust sanitization.

The fix involves:
1. Installing the `sanitize-html` library.
2. Replacing the `content.replace(/<[^>]*>/g, "")` line with a call to `sanitize-html` to sanitize the content properly.
3. Ensuring that the `sanitize-html` library is imported at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
